### PR TITLE
Add the IO Type ID of LED Light

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2199,34 +2199,37 @@ List <strong>NOT</strong> guaranteed up to date!</td>
 <tr class="row-even"><td>0x0005</td>
 <td>Button</td>
 </tr>
-<tr class="row-odd"><td>0x0014</td>
+<tr class="row-odd"><td>0x0008</td>
+<td>LED Light</td>
+</tr>
+<tr class="row-even"><td>0x0014</td>
 <td>Voltage</td>
 </tr>
-<tr class="row-even"><td>0x0015</td>
+<tr class="row-odd"><td>0x0015</td>
 <td>Current</td>
 </tr>
-<tr class="row-odd"><td>0x0016</td>
+<tr class="row-even"><td>0x0016</td>
 <td>Piezo Tone (Sound)</td>
 </tr>
-<tr class="row-even"><td>0x0017</td>
+<tr class="row-odd"><td>0x0017</td>
 <td>RGB Light</td>
 </tr>
-<tr class="row-odd"><td>0x0022</td>
+<tr class="row-even"><td>0x0022</td>
 <td>External Tilt Sensor</td>
 </tr>
-<tr class="row-even"><td>0x0023</td>
+<tr class="row-odd"><td>0x0023</td>
 <td>Motion Sensor</td>
 </tr>
-<tr class="row-odd"><td>0x0025</td>
+<tr class="row-even"><td>0x0025</td>
 <td>Vision Sensor</td>
 </tr>
-<tr class="row-even"><td>0x0026</td>
+<tr class="row-odd"><td>0x0026</td>
 <td>External Motor with Tacho</td>
 </tr>
-<tr class="row-odd"><td>0x0027</td>
+<tr class="row-even"><td>0x0027</td>
 <td>Internal Motor with Tacho</td>
 </tr>
-<tr class="row-even"><td>0x0028</td>
+<tr class="row-odd"><td>0x0028</td>
 <td>Internal Tilt</td>
 </tr>
 </tbody>


### PR DESCRIPTION
Thank you for such a wonderful document!

I added an IO Type ID which I got when attaching [88005 LEGO® Powered Up LED Light](https://shop.lego.com/en-US/product/LEGO-Powered-Up-LED-Light-88005) to hub.
