### PR TITLE
index:StartPower(Power1,Power2): removed WriteDirectModeData

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4925,9 +4925,8 @@ Turn on/off both motors</p>
 </td>
 <td><p class="first">Single:
 N/A</p>
-<p>Synchronized:
+<p class="last">Synchronized:
 Turn on/off BOTH motors unregulated.</p>
-<p class="last"><code class="docutils literal"><span class="pre">Encoded</span> <span class="pre">through</span></code> <a class="reference internal" href="#wr-dmd"><span class="std std-ref">WriteDirectModeData</span></a></p>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
Fixed the StartPower(Power1, Power2) function (Output Command 0x81 - Sub Command 0x02) command type in the description column.
This command uses normal "Port Output Command" (0x81, 0x02) not the "WriteDirectDataMode" (0x81, 0x51).