### PR TITLE
Fixing some typos and mistakes around SetRgbColors

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7028,7 +7028,7 @@ ColorNo for later mode (0x00).</td>
 </tr>
 <tr class="row-even"><td><p class="first">SetRgbColors(RedColor,
 GreenColor, BlueColor)</p>
-<p class="last">Mode 0</p>
+<p class="last">Mode 1</p>
 </td>
 <td>Port ID, <a class="reference internal" href="index.html#st-comp"><span class="std std-ref">Startup and Completion Information</span></a>,
 0x51, 0x00, 0x51, 0x01, R, G, B</td>

--- a/docs/index.html
+++ b/docs/index.html
@@ -5844,7 +5844,7 @@ the addressed H/W.
 </table>
 </div>
 <div class="section" id="output-sub-command-setrgbcolorno-redcolor-greencolor-bluecolor-n-a">
-<h4>3.27.21. Output Sub Command - SetRgbColorNo(RedColor, GreenColor, BlueColor) N/A<a class="headerlink" href="#output-sub-command-setrgbcolorno-redcolor-greencolor-bluecolor-n-a" title="Permalink to this headline">¶</a></h4>
+<h4>3.27.21. Output Sub Command - SetRgbColors(RedColor, GreenColor, BlueColor) N/A<a class="headerlink" href="#output-sub-command-setrgbcolorno-redcolor-greencolor-bluecolor-n-a" title="Permalink to this headline">¶</a></h4>
 <table border="1" class="docutils">
 <colgroup>
 <col width="27%" />
@@ -5853,7 +5853,7 @@ the addressed H/W.
 <col width="32%" />
 </colgroup>
 <thead valign="bottom">
-<tr class="row-odd"><th class="head" colspan="4">SetRgbColorNo(RedColor, GreenColor, BlueColor) : Output Command 0x81 - Sub Command N/A</th>
+<tr class="row-odd"><th class="head" colspan="4">SetRgbColors(RedColor, GreenColor, BlueColor) : Output Command 0x81 - Sub Command N/A</th>
 </tr>
 </thead>
 <tbody valign="top">

--- a/docs/index.html
+++ b/docs/index.html
@@ -7065,8 +7065,7 @@ preset/reset in mode different from actual, but the user has to check the inform
 <td>Set the Tilt into TiltImpactCount mode (0x03)
 and change (preset) the value to PresetValue.</td>
 </tr>
-<tr class="row-even"><td><p class="first">SetRgbColors(RedColor,
-GreenColor, BlueColor)</p>
+<tr class="row-even"><td><p class="first">TiltConfigOrientation(Orientation)</p>
 <p class="last">Mode 5</p>
 </td>
 <td>Port ID, <a class="reference internal" href="index.html#st-comp"><span class="std std-ref">Startup and Completion Information</span></a>,

--- a/docs/index.html
+++ b/docs/index.html
@@ -7031,7 +7031,7 @@ GreenColor, BlueColor)</p>
 <p class="last">Mode 1</p>
 </td>
 <td>Port ID, <a class="reference internal" href="index.html#st-comp"><span class="std std-ref">Startup and Completion Information</span></a>,
-0x51, 0x00, 0x51, 0x01, R, G, B</td>
+0x51, 0x01, R, G, B</td>
 <td>Set the RGB LED to Colors for instant Colors
 (if RGB already in mode 1) <sup>[M]</sup> .</td>
 </tr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,7 +8,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>LEGO Wireless Protocol 3.0.00 Doc v3.0.00 r17 documentation</title>
+  <title>LEGO Wireless Protocol 3.0.00 Doc v3.0.00 r18 documentation</title>
   
 
   


### PR DESCRIPTION
Some fixes around SetRgbColors

- fixes method name. SetRgbColors fo Red-Green-Blue params, and SetRgbColorNo for ColorNumber param. In some places was mixed
- mistakely SetRgbColors  was referenced in TiltConfigOrientation block
- fixed. SetRgbColors works in Mode 1, not in Mode 0
- fixed sequence for SetRgbColors `0x51, 0x01, R, G, B` is right (0x51, 0x00, 0x51, 0x01, R, G, B is wrong)

checked behaviour with sources of https://github.com/undera/pylgbst , https://github.com/corneliusmunz/legoino, https://github.com/sharpbrick/powered-up